### PR TITLE
Generate Inorm tables for phoebe < 2.5

### DIFF
--- a/server.py
+++ b/server.py
@@ -121,7 +121,7 @@ def _unpack_version_request(phoebe_version_request):
     else:
         return phoebe_version_request
 
-def _generate_request_passband(pbr, content_request, export_legacy_tables=False, gzipped=False, save=True):
+def _generate_request_passband(pbr, content_request, export_inorm_tables=False, gzipped=False, save=True):
     if app._verbose:
         print("_generate_request_passband {} {} gzipped={} save={}".format(pbr, content_request, gzipped, save))
 
@@ -153,11 +153,11 @@ def _generate_request_passband(pbr, content_request, export_legacy_tables=False,
         pbf = tempfile.NamedTemporaryFile(mode='w+b', dir=tmpdir, prefix=prefix, suffix=".fits.gz" if gzipped else ".fits")
         if gzipped:
             gzf = gzip.GzipFile(mode='wb', fileobj=pbf)
-            pb.save(gzf, export_legacy_tables=export_legacy_tables, update_timestamp=False)
+            pb.save(gzf, export_inorm_tables=export_inorm_tables, update_timestamp=False)
             return gzf, filename
 
         else:
-            pb.save(pbf, export_legacy_tables=export_legacy_tables, update_timestamp=False)
+            pb.save(pbf, export_inorm_tables=export_inorm_tables, update_timestamp=False)
             return pbf, filename
 
     else:
@@ -320,8 +320,8 @@ def pbs_unpack_request(passband_request='all', content_request='all'):
 
     generated = {}
     for pbr in passband_request:
-        export_legacy_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
-        pb = _generate_request_passband(pbr, content_request, export_legacy_tables=export_legacy_tables, gzipped=gzipped, save=False)
+        export_inorm_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
+        pb = _generate_request_passband(pbr, content_request, export_inorm_tables=export_inorm_tables, gzipped=gzipped, save=False)
         generated["{}:{}".format(pb.pbset, pb.pbname)] = pb.content
 
     return _get_response({'phoebe_version_request': phoebe_version_request,
@@ -361,8 +361,8 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         created_tmp_files.append(tbf)
 
         for pbr in passband_request:
-            export_legacy_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
-            pbf, pbfname = _generate_request_passband(pbr, content_request, export_legacy_tables=export_legacy_tables, gzipped=gzipped, save=True)
+            export_inorm_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
+            pbf, pbfname = _generate_request_passband(pbr, content_request, export_inorm_tables=export_inorm_tables, gzipped=gzipped, save=True)
             created_tmp_files.append(pbf)
 
             tar.add(pbf.name, arcname=pbfname)
@@ -370,8 +370,8 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         return send_file(tbf.name, as_attachment=True, download_name='generated_phoebe_tables.tar.gz')
 
     # if we're here, then we know we're a list with only one entry
-    export_legacy_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
-    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, export_legacy_tables=export_legacy_tables, gzipped=gzipped, save=True)
+    export_inorm_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
+    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, export_inorm_tables=export_inorm_tables, gzipped=gzipped, save=True)
     created_tmp_files.append(pbf)
 
     return send_file(pbf.name, as_attachment=True, download_name=pbfname)

--- a/server.py
+++ b/server.py
@@ -62,6 +62,27 @@ def _string_to_bool(value):
     else:
         raise ValueError("{} could not be cast to bool".format(value))
 
+def is_legacy(phoebe_version):
+    """
+    Returns True if the version is less than 2.5
+    
+    Arguments
+    ---------
+    phoebe_version : str
+        The version string to compare
+    
+    Returns
+    -------
+    bool
+        True if the version is less than 2.5, False otherwise
+    """
+
+    try:
+        return version.parse(phoebe_version) < version.parse('2.5')
+    except ValueError:
+        # can't parse the version, so assume it's legacy
+        return True
+
 ############################ HTTP ROUTES ######################################
 def _get_response(data, status_code=200):
     resp = jsonify(data)
@@ -320,8 +341,7 @@ def pbs_unpack_request(passband_request='all', content_request='all'):
 
     generated = {}
     for pbr in passband_request:
-        export_inorm_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
-        pb = _generate_request_passband(pbr, content_request, export_inorm_tables=export_inorm_tables, gzipped=gzipped, save=False)
+        pb = _generate_request_passband(pbr, content_request, export_inorm_tables=is_legacy(phoebe_version_request), gzipped=gzipped, save=False)
         generated["{}:{}".format(pb.pbset, pb.pbname)] = pb.content
 
     return _get_response({'phoebe_version_request': phoebe_version_request,
@@ -361,8 +381,7 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         created_tmp_files.append(tbf)
 
         for pbr in passband_request:
-            export_inorm_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
-            pbf, pbfname = _generate_request_passband(pbr, content_request, export_inorm_tables=export_inorm_tables, gzipped=gzipped, save=True)
+            pbf, pbfname = _generate_request_passband(pbr, content_request, export_inorm_tables=is_legacy(phoebe_version_request), gzipped=gzipped, save=True)
             created_tmp_files.append(pbf)
 
             tar.add(pbf.name, arcname=pbfname)
@@ -370,8 +389,7 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         return send_file(tbf.name, as_attachment=True, download_name='generated_phoebe_tables.tar.gz')
 
     # if we're here, then we know we're a list with only one entry
-    export_inorm_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
-    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, export_inorm_tables=export_inorm_tables, gzipped=gzipped, save=True)
+    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, export_inorm_tables=is_legacy(phoebe_version_request), gzipped=gzipped, save=True)
     created_tmp_files.append(pbf)
 
     return send_file(pbf.name, as_attachment=True, download_name=pbfname)

--- a/server.py
+++ b/server.py
@@ -62,7 +62,7 @@ def _string_to_bool(value):
     else:
         raise ValueError("{} could not be cast to bool".format(value))
 
-def is_legacy(phoebe_version):
+def requires_inorm_tables(phoebe_version):
     """
     Returns True if the version is less than 2.5
     
@@ -341,7 +341,7 @@ def pbs_unpack_request(passband_request='all', content_request='all'):
 
     generated = {}
     for pbr in passband_request:
-        pb = _generate_request_passband(pbr, content_request, export_inorm_tables=is_legacy(phoebe_version_request), gzipped=gzipped, save=False)
+        pb = _generate_request_passband(pbr, content_request, export_inorm_tables=requires_inorm_tables(phoebe_version_request), gzipped=gzipped, save=False)
         generated["{}:{}".format(pb.pbset, pb.pbname)] = pb.content
 
     return _get_response({'phoebe_version_request': phoebe_version_request,
@@ -381,7 +381,7 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         created_tmp_files.append(tbf)
 
         for pbr in passband_request:
-            pbf, pbfname = _generate_request_passband(pbr, content_request, export_inorm_tables=is_legacy(phoebe_version_request), gzipped=gzipped, save=True)
+            pbf, pbfname = _generate_request_passband(pbr, content_request, export_inorm_tables=requires_inorm_tables(phoebe_version_request), gzipped=gzipped, save=True)
             created_tmp_files.append(pbf)
 
             tar.add(pbf.name, arcname=pbfname)
@@ -389,7 +389,7 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         return send_file(tbf.name, as_attachment=True, download_name='generated_phoebe_tables.tar.gz')
 
     # if we're here, then we know we're a list with only one entry
-    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, export_inorm_tables=is_legacy(phoebe_version_request), gzipped=gzipped, save=True)
+    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, export_inorm_tables=requires_inorm_tables(phoebe_version_request), gzipped=gzipped, save=True)
     created_tmp_files.append(pbf)
 
     return send_file(pbf.name, as_attachment=True, download_name=pbfname)

--- a/server.py
+++ b/server.py
@@ -82,7 +82,7 @@ def requires_inorm_tables(phoebe_version):
     version_base = re.match(r'(\d+\.\d+\.\d+)', phoebe_version)
 
     try:
-        return version.parse(version_base) < version.parse('2.5')
+        return version.parse(version_base.group(1)) < version.parse('2.5')
     except ValueError:
         # can't parse the version, so assume it's legacy
         return True

--- a/server.py
+++ b/server.py
@@ -36,6 +36,7 @@ import tempfile
 import tarfile
 import gzip
 from datetime import datetime
+from packaging import version
 
 phoebe.interactive_off()
 
@@ -120,7 +121,7 @@ def _unpack_version_request(phoebe_version_request):
     else:
         return phoebe_version_request
 
-def _generate_request_passband(pbr, content_request, gzipped=False, save=True):
+def _generate_request_passband(pbr, content_request, export_legacy_tables=False, gzipped=False, save=True):
     if app._verbose:
         print("_generate_request_passband {} {} gzipped={} save={}".format(pbr, content_request, gzipped, save))
 
@@ -152,11 +153,11 @@ def _generate_request_passband(pbr, content_request, gzipped=False, save=True):
         pbf = tempfile.NamedTemporaryFile(mode='w+b', dir=tmpdir, prefix=prefix, suffix=".fits.gz" if gzipped else ".fits")
         if gzipped:
             gzf = gzip.GzipFile(mode='wb', fileobj=pbf)
-            pb.save(gzf, update_timestamp=False)
+            pb.save(gzf, export_legacy_tables=export_legacy_tables, update_timestamp=False)
             return gzf, filename
 
         else:
-            pb.save(pbf, update_timestamp=False)
+            pb.save(pbf, export_legacy_tables=export_legacy_tables, update_timestamp=False)
             return pbf, filename
 
     else:
@@ -319,7 +320,8 @@ def pbs_unpack_request(passband_request='all', content_request='all'):
 
     generated = {}
     for pbr in passband_request:
-        pb = _generate_request_passband(pbr, content_request, gzipped=gzipped, save=False)
+        export_legacy_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
+        pb = _generate_request_passband(pbr, content_request, export_legacy_tables=export_legacy_tables, gzipped=gzipped, save=False)
         generated["{}:{}".format(pb.pbset, pb.pbname)] = pb.content
 
     return _get_response({'phoebe_version_request': phoebe_version_request,
@@ -359,7 +361,8 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         created_tmp_files.append(tbf)
 
         for pbr in passband_request:
-            pbf, pbfname = _generate_request_passband(pbr, content_request, gzipped=gzipped, save=True)
+            export_legacy_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
+            pbf, pbfname = _generate_request_passband(pbr, content_request, export_legacy_tables=export_legacy_tables, gzipped=gzipped, save=True)
             created_tmp_files.append(pbf)
 
             tar.add(pbf.name, arcname=pbfname)
@@ -367,7 +370,8 @@ def pbs_generate_and_serve(passband_request='all', content_request='all',):
         return send_file(tbf.name, as_attachment=True, download_name='generated_phoebe_tables.tar.gz')
 
     # if we're here, then we know we're a list with only one entry
-    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, gzipped=gzipped, save=True)
+    export_legacy_tables = phoebe_version_request == 'latest' or version.parse(phoebe_version_request) < version.parse('2.5')
+    pbf, pbfname = _generate_request_passband(passband_request[0], content_request, export_legacy_tables=export_legacy_tables, gzipped=gzipped, save=True)
     created_tmp_files.append(pbf)
 
     return send_file(pbf.name, as_attachment=True, download_name=pbfname)

--- a/server.py
+++ b/server.py
@@ -37,6 +37,7 @@ import tarfile
 import gzip
 from datetime import datetime
 from packaging import version
+import re
 
 phoebe.interactive_off()
 
@@ -77,8 +78,11 @@ def requires_inorm_tables(phoebe_version):
         True if the version is less than 2.5, False otherwise
     """
 
+    # normalize version number if necessary:
+    version_base = re.match(r'(\d+\.\d+\.\d+)', phoebe_version)
+
     try:
-        return version.parse(phoebe_version) < version.parse('2.5')
+        return version.parse(version_base) < version.parse('2.5')
     except ValueError:
         # can't parse the version, so assume it's legacy
         return True


### PR DESCRIPTION
PHOEBE versions 2.4 and earlier require standalone Inorm tables in passband files. The server now checks the version and exports the legacy tables to the requester.