### PR TITLE
support redirecting for older versions of phoebe

### DIFF
--- a/server.py
+++ b/server.py
@@ -16,6 +16,14 @@ app = Flask(__name__)
 CORS(app)
 app._verbose = True
 
+class VersionRedirect(Exception):
+    def __init__(self, url):
+        self.url = url
+
+@app.errorhandler(VersionRedirect)
+def handle_version_redirect(e):
+    return redirect(e.url, 302)
+
 import os
 pwd = os.path.dirname(os.path.abspath(__file__))
 tmpdir = os.path.join(pwd, 'flask_server_generated_tables')
@@ -38,6 +46,9 @@ import gzip
 from datetime import datetime
 from packaging import version
 import re
+
+phoebe_version_server = phoebe.__version__
+phoebe_version_latest = '2.4'  # TODO: update this on new phoebe release or retrieve dynamically from website/GH/pip
 
 phoebe.interactive_off()
 
@@ -86,6 +97,26 @@ def requires_inorm_tables(phoebe_version):
     except ValueError:
         # can't parse the version, so assume it's legacy
         return True
+
+def tables_subdomain(phoebe_version):
+    """
+    Returns the subdomain for the given phoebe version.
+    
+    Arguments
+    ---------
+    phoebe_version : str
+        The version string to compare
+    
+    Returns
+    -------
+    str
+        The subdomain for the given phoebe version
+    """
+
+    if version.parse(phoebe_version) < version.parse('2.5'):
+        return 'tables-20-24.phoebe-project.org'
+    else:
+        return 'tables.phoebe-project.org'
 
 ############################ HTTP ROUTES ######################################
 def _get_response(data, status_code=200):
@@ -142,9 +173,15 @@ def _expand_content_item(pb, cr_item):
 
 def _unpack_version_request(phoebe_version_request):
     if phoebe_version_request == 'latest':
-        return phoebe.__version__
-    else:
-        return phoebe_version_request
+        phoebe_version_request = phoebe_version_latest
+
+    subdomain_request = tables_subdomain(phoebe_version_request)
+
+    if subdomain_request != tables_subdomain(phoebe_version_server):
+        full_path = request.full_path.rstrip('?')
+        raise VersionRedirect(f"https://{subdomain_request}{full_path}")
+
+    return phoebe_version_request
 
 def _generate_request_passband(pbr, content_request, export_inorm_tables=False, gzipped=False, save=True):
     if app._verbose:
@@ -206,12 +243,12 @@ def redirect_to_form_pbs():
 @app.route('/info', methods=['GET'])
 def info():
     if app._verbose:
-        print("info", sys.version_info, phoebe.__version__)
+        print("info", sys.version_info, phoebe_version_server)
 
     version_info = sys.version_info
 
     return _get_response({'python_version_server': "{}.{}.{}".format(version_info.major, version_info.minor, version_info.micro),
-                          'phoebe_version_server': phoebe.__version__})
+                          'phoebe_version_server': phoebe_version_server})
 
 @app.route('/flush', methods=['GET'])
 def flush():

--- a/server.py
+++ b/server.py
@@ -43,25 +43,40 @@ from astropy.io import fits
 import tempfile
 import tarfile
 import gzip
+import urllib.request
+import json
 from datetime import datetime
 from packaging import version
 import re
 
 phoebe_version_server = phoebe.__version__
-phoebe_version_latest = '2.4'  # TODO: update this on new phoebe release or retrieve dynamically from website/GH/pip
-
 phoebe.interactive_off()
 
+def _get_phoebe_version_latest():
+    global _phoebe_version_latest_cache
+    if _phoebe_version_latest_cache is None:
+        try:
+            with urllib.request.urlopen('https://pypi.org/pypi/phoebe/json', timeout=3) as r:
+                _phoebe_version_latest_cache = json.loads(r.read())['info']['version']
+        except Exception:
+            return '2.4'  # hardcoded fallback if PyPI unreachable
+    return _phoebe_version_latest_cache
+
+
 def _pbs_flush(force=False):
-    global _pbs_last_flush
+    global _pbs_last_flush, _phoebe_version_latest_cache
     if _pbs_last_flush is None or force or (datetime.now()-_pbs_last_flush).total_seconds() > (60*60):
         print("flushing passbands cache")
         phoebe.atmospheres.passbands._pbtable = {}
         phoebe.atmospheres.passbands._init_passbands(refresh=True, query_online=False, passband_directories=datadir)
+        _phoebe_version_latest_cache = None
         _pbs_last_flush = datetime.now()
+
 
 global _pbs_last_flush
 _pbs_last_flush = None
+global _phoebe_version_latest_cache
+_phoebe_version_latest_cache = None
 _pbs_flush()
 
 def _string_to_bool(value):
@@ -173,7 +188,7 @@ def _expand_content_item(pb, cr_item):
 
 def _unpack_version_request(phoebe_version_request):
     if phoebe_version_request == 'latest':
-        phoebe_version_request = phoebe_version_latest
+        phoebe_version_request = _get_phoebe_version_latest()
 
     subdomain_request = tables_subdomain(phoebe_version_request)
 


### PR DESCRIPTION
This implements in-flask redirecting to the appropriate subdomain/container running the _same_ server code but a different version of phoebe.  It does so by:

* having smarter logic to map "?phoebe_version=latest" to the actual latest version, by looking at pypi, with the cache being reset with passbands every hour
* every request that uses `?phoebe_version` will run through `_unpack_version_request` and compares the version > subdomain mapping (in `tables_subdomain`) between the requested-version of PHOEBE with the version running on this instance of the server.  If they are different, flask will redirect to the subdomain mapped from the requested-version of PHOEBE (which will then run the same logic and see that it is a match, and continue to process the request).

`tables.phoebe-project.org` _remains_ the publicly accessible endpoint used by the website and PHOEBE code (and will going forward).  As new versions of PHOEBE motivate new subdomains/containers, we should update the logic in `tables_subdomain` to create a new subdomain for what was previously covered by the default and deploy to _all_ running instances.